### PR TITLE
Correct kilo symbol.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,7 +173,7 @@ impl PrefixNames for Prefix {
 
     fn symbol(&self) -> &'static str {
         match *self {
-            Kilo => "K",  Mega => "M",  Giga => "G",  Tera => "T",
+            Kilo => "k",  Mega => "M",  Giga => "G",  Tera => "T",
             Peta => "P",  Exa => "E",  Zetta => "Z",  Yotta => "Y",
             Kibi => "Ki", Mibi => "Mi", Gibi => "Gi", Tebi => "Ti",
             Pebi => "Pi", Exbi => "Ei", Zebi => "Zi", Yobi => "Yi",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -339,7 +339,7 @@ mod test {
 			Prefixed(prefix, n) => format!("The file is {:.1} {}B in size", n, prefix),
 		};
 
-		assert_eq!(result, "The file is 8.5 KB in size");
+		assert_eq!(result, "The file is 8.5 kB in size");
     }
 
     #[test]


### PR DESCRIPTION
Kilo is lowercase in SI.
